### PR TITLE
use patched ct-ng

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ rm -f /vagrant/*.bin
 cd 
 
 [ -d "crosstool-NG" ] || {
-	git clone --recursive -b xtensa-1.22.x 'https://github.com/espressif/crosstool-NG.git'
+	git clone --recursive -b xtensa-1.22.x 'https://github.com/frostworx/crosstool-NG.git'
 	cd 'crosstool-NG'
 	./bootstrap
 	./configure --enable-local


### PR DESCRIPTION
I applied some minor patches to the crosstools branch used, so the project can be compiled successfully.
Unlikely that this PR _(or the [xtensa PR](https://github.com/espressif/crosstool-NG/pull/38))_ get merged, but it might help some people to find a working fork.